### PR TITLE
Fix “Your test suite must contain at least one test” problem when `it`/`test` is used without `describe`

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,6 +1,7 @@
 import Allure from "allure-js-commons";
 import stripAnsi from "strip-ansi";
 import { Reporter } from "./Reporter";
+import { relative } from "path";
 
 declare namespace jasmine {
     function getEnv(): any;
@@ -30,16 +31,16 @@ class JasmineAllureReporter implements jasmine.CustomReporter {
         this.allure = allure;
     }
 
-    suiteStarted(suite: jasmine.CustomReporterResult) {
-        this.allure.startSuite(suite.fullName);
-    }
+    jasmineStarted() {
+        this.allure.startSuite(relative(process.cwd(), (expect as any).getState().testPath));
+    };
 
-    suiteDone() {
+    jasmineDone() {
         this.allure.endSuite();
     };
 
     specStarted(spec: jasmine.CustomReporterResult) {
-        this.allure.startCase(spec.description);
+        this.allure.startCase(spec.fullName);
     };
 
     specDone(spec: jasmine.CustomReporterResult) {


### PR DESCRIPTION
If we use `test()` or `it()` without putting it in `describe` block, when this reporter is active, the test will fail with this confusing error message:

    Your test suite must contain at least one test

Inspecting further, I found that `allure.startCase()` will error out if `allure.startSuite` has not been called before.

To fix this, I changed the notion of `suite` and `case`. Now, 1 test file = 1 suite, regardless of `describe` blocks. The title of each `describe` block is prepended to each case. This matches the behavior of `jest-junit`.