### PR TITLE
fix allure imports

### DIFF
--- a/src/Reporter.ts
+++ b/src/Reporter.ts
@@ -1,4 +1,4 @@
-import Allure from "allure-js-commons";
+import Allure = require("allure-js-commons");
 
 export enum Status {
     Passed = "passed",

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,4 +1,4 @@
-import Allure from "allure-js-commons";
+import Allure = require("allure-js-commons");
 import stripAnsi from "strip-ansi";
 import { Reporter } from "./Reporter";
 


### PR DESCRIPTION
Fix imports types because of `export = Allure;` in types/allure-js-commons

Source:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/allure-js-commons/index.d.ts#L35

Typescript says:
> When exporting a module using export =, TypeScript-specific import module = require("module") must be used to import the module.

https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/Modules.md#export--and-import--require

