### PR TITLE
Add support for TMS link

### DIFF
--- a/examples/__tests__/test1.js
+++ b/examples/__tests__/test1.js
@@ -20,7 +20,8 @@ describe(
             reporter
                 .description("Home Page test suite")
                 .story("GOOGL-01")
-                .severity(Severity.Critical);
+                .severity(Severity.Critical)
+                .testId('TEST-01');
 
             const text = await page.evaluate(() => document.body.textContent);
 

--- a/src/Reporter.ts
+++ b/src/Reporter.ts
@@ -48,6 +48,11 @@ export class Reporter {
         return this;
     }
 
+    public testId(testId: string) {
+        this.addLabel('testId', testId);
+        return this;
+    }
+
     public startStep(name: string) {
         this.allure.startStep(name);
         return this;


### PR DESCRIPTION
Added support for linking TMS test id's using `testId`.

Result:
![2020-02-11 20_46_03-Poczta](https://user-images.githubusercontent.com/13874614/74273295-825a6880-4d10-11ea-905c-eeb1f9647f1e.png)
