### PR TITLE
Added types declaration usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.1",
   "description": "Allure Reports for jest",
   "main": "dist/index",
+  "types": "dist/setup.d.ts",
   "repository": "git@github.com:zaqqaz/jest-allure.git",
   "author": "Denis Artyuhovich (zaqqaz) <i@denis.by>",
   "license": "MIT",


### PR DESCRIPTION
An attempt to fix TS issue:

```
xxx.spec.tsx:21:9 - error TS2304: Cannot find name 'reporter'.
21  reporter.epic('xxx');
```

I've added following to my `tsconfig`, but it still fails:

```json
{
  "compilerOptions": {
    ...,
    "typeRoots": [
      "node_modules/@types",
      "node_modules/jest-allure/dist"
    ]
}
```

Funny part is that tests are passing, since Jest use Babel to transpile, which does not verify types.