### PR TITLE
Update strip-ansi to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-allure",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "Allure Reports for jest",
   "main": "dist/index",
   "repository": "git@github.com:zaqqaz/jest-allure.git",
@@ -26,8 +26,8 @@
     "@types/allure-js-commons": "^0.0.0",
     "@types/jest": "^22.2.3",
     "@types/node": "^10.1.2",
-    "@types/strip-ansi": "^3.0.0",
+    "@types/strip-ansi": "^5.0.0",
     "allure-js-commons": "^1.3.2",
-    "strip-ansi": "^4.0.0"
+    "strip-ansi": "^7.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,9 +14,12 @@
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.1.2.tgz#1b928a0baa408fc8ae3ac012cc81375addc147c6"
 
-"@types/strip-ansi@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/strip-ansi/-/strip-ansi-3.0.0.tgz#9b63d453a6b54aa849182207711a08be8eea48ae"
+"@types/strip-ansi@^5.0.0":
+  version "5.2.1"
+  resolved "https://artifactory.sonos.com:443/artifactory/api/npm/services-npm/@types/strip-ansi/-/strip-ansi-5.2.1.tgz#acd97f1f091e332bb7ce697c4609eb2370fa2a92"
+  integrity sha512-1l5iM0LBkVU8JXxnIoBqNvg+yyOXxPeN6DNoD+7A9AN1B8FhYPSeIXgyNqwIqg1uzipTgVC2hmuDzB0u9qw/PA==
+  dependencies:
+    strip-ansi "*"
 
 allure-js-commons@^1.3.2:
   version "1.3.2"
@@ -29,9 +32,10 @@ allure-js-commons@^1.3.2:
     object-assign "^4.1.1"
     uuid "^3.0.0"
 
-ansi-regex@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://artifactory.sonos.com:443/artifactory/api/npm/services-npm/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
 file-type@^7.7.1:
   version "7.7.1"
@@ -69,11 +73,12 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+strip-ansi@*, strip-ansi@^7.0.0:
+  version "7.0.1"
+  resolved "https://artifactory.sonos.com:443/artifactory/api/npm/services-npm/strip-ansi/-/strip-ansi-7.0.1.tgz#61740a08ce36b61e50e65653f07060d000975fb2"
+  integrity sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==
   dependencies:
-    ansi-regex "^3.0.0"
+    ansi-regex "^6.0.1"
 
 typescript@^2.8.3:
   version "2.8.3"


### PR DESCRIPTION
Fixes the following vulnerability 
```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ moderate      │  Inefficient Regular Expression Complexity in                │
│               │ chalk/ansi-regex                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ ansi-regex                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=5.0.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ jest-allure                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ jest-allure > strip-ansi > ansi-regex                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1064843                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
```